### PR TITLE
Fix error with large datasets by updating file format to XLSX

### DIFF
--- a/Utilities_Matlab/MyUtilities/Murat_testAll.m
+++ b/Utilities_Matlab/MyUtilities/Murat_testAll.m
@@ -94,7 +94,7 @@ end
 muratHeader                 =   table(Names,Origin,P,S,EvLat,EvLon,...
     EvDepth,StLat,StLon,StElev);
 
-writetable(muratHeader,'DataHeaders.xls');
+writetable(muratHeader,'DataHeaders.xlsx');
 
 end
 %%

--- a/bin/Murat_checks.m
+++ b/bin/Murat_checks.m
@@ -2,7 +2,8 @@
 function Murat                  =   Murat_checks(Murat)
 
 % INPUTS
-dataDirectory                   =   ['./' Murat.input.dataDirectory];
+%dataDirectory                   =   ['./' Murat.input.dataDirectory];
+dataDirectory                   =   [Murat.input.dataDirectory]; %if data is outside of current folder
 FPath                           =   './';
 FLabel                          =   Murat.input.label;
 PTime                           =   ['SAChdr.times.' Murat.input.PTime];

--- a/bin/Murat_inversion.m
+++ b/bin/Murat_inversion.m
@@ -256,4 +256,4 @@ Murat.data.residualQ                =   residualQ;
 Murat.data.modvPeakDelay            =   modv_pd;
 Murat.data.modvQc                   =   modv_Qc;
 Murat.data.modvQ                    =   modv_Q;
-writetable(muratHeader,fullfile(FPath, FLabel, 'TXT', 'DataHeaders.xls'));
+writetable(muratHeader,fullfile(FPath, FLabel, 'TXT', 'DataHeaders.xlsx'));


### PR DESCRIPTION
I encountered an error while working with a large dataset in the murat_inversion module. The error is depicted in the following screenshot:
![error_with_xls](https://github.com/LucaDeSiena/MuRAT/assets/96948399/c94c874b-052f-40cb-929f-84ae57606e8a)
To address this issue, I have made the following modification: I replaced the file format from "xls" to "xlsx" in the affected code. This modification successfully resolves the error and allows for the correct processing of large datasets.
### **_**Comparison between XLS and XLSX:**_** 
To provide a better understanding of the changes made, it is important to note the differences between the XLS and XLSX file formats:
**1. **XLS workbook limitations:**** - Maximum of 65,536 rows (2^16) 
**2. XLSX workbook capabilities:** - Supports up to 1,048,576 rows (2^20). 
We can effectively handle larger datasets, benefiting from the expanded row and column limits. 